### PR TITLE
refactor: replace ClosedXML with ExcelDataReader for scalable Excel i…

### DIFF
--- a/SQLBulkCopy.csproj
+++ b/SQLBulkCopy.csproj
@@ -9,7 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.105.0" />
+    <PackageReference Include="ExcelDataReader" Version="3.7.0" />
+    <PackageReference Include="ExcelDataReader.DataSet" Version="3.7.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR replaces `ClosedXML` with `ExcelDataReader` to reduce memory footprint and enable streaming read of `.xlsx` files. The original ClosedXML-based implementation loaded entire workbooks into memory, which became unstable for files exceeding ~50k rows.